### PR TITLE
Fix config "customConfig"

### DIFF
--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -66,6 +66,8 @@ class CKEditorWidget(forms.Textarea):
                                 setting must be a dictionary type.' % \
                                 config_name)
                     # Override defaults with settings config.
+                    if 'customConfig' in config:
+                        self.config = {}
                     self.config.update(config)
                 else:
                     raise ImproperlyConfigured("No configuration named '%s' \


### PR DESCRIPTION
As default in "CKEDITOR.replace" parameters have higher priority than configs in js file from "customConfig" parameter. And when we set "customConfig", the other parameters of CKEDITOR_CONFIGS should not be. But earlier was set DEFAULT_CONFIG with other parameters. I fix it
