### PR TITLE
Remove duplicate installation instruction.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,6 @@ Required
    CKEditor has been tested with django FileSystemStorage and S3BotoStorage.
    There are issues using S3Storage from django-storages.
 
-#. Run the ``collectstatic`` management command: ``$ /manage.py collectstatic``. This'll copy static CKEditor require media resources into the directory given by the ``STATIC_ROOT`` setting. See `Django's documentation on managing static files <https://docs.djangoproject.com/en/dev/howto/static-files>`_ for more info.
-
 #. Add CKEditor URL include to your project's ``urls.py`` file::
 
     (r'^ckeditor/', include('ckeditor.urls')),


### PR DESCRIPTION
Instruction to run `collectstatic` appears twice. 

Thanks for maintaining this fork, by the way!
