### PR TITLE
Python 3.2 compatibility

### DIFF
--- a/ckeditor/utils.py
+++ b/ckeditor/utils.py
@@ -6,7 +6,7 @@ from django.template.defaultfilters import slugify
 
 
 def slugify_filename(filename):
-    u""" Slugify filename """
+    """ Slugify filename """
     name, ext = os.path.splitext(filename)
     return slugify(name) + ext
 


### PR DESCRIPTION
Hi, thank you for maintaining and updating django-ckeditor. I made this minimal change to make it work with Python 3.2. I would appreciate if you would like to accept it as on some systems, 3.2 is the highest version of Python 3.x provided, and it does not support the "u" prefix.
