### PR TITLE
Fix language stuck to English

### DIFF
--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -5,6 +5,7 @@ from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.utils.html import conditional_escape
 from django.utils.encoding import force_text
+from django.utils.translation import get_language
 from django.core.exceptions import ImproperlyConfigured
 from django.forms.util import flatatt
 import json
@@ -81,6 +82,9 @@ class CKEditorWidget(forms.Textarea):
         final_attrs = self.build_attrs(attrs, name=name)
         self.config.setdefault('filebrowserUploadUrl', reverse('ckeditor_upload'))
         self.config.setdefault('filebrowserBrowseUrl', reverse('ckeditor_browse'))
+        if not self.config.get('language'):
+            self.config['language'] = get_language()
+
         return mark_safe(render_to_string('ckeditor/widget.html', {
             'final_attrs': flatatt(final_attrs),
             'value': conditional_escape(force_text(value)),


### PR DESCRIPTION
On multi-language sites, the language is not properly selected for the interface.
