### PR TITLE
Add support for external plugin resource declarations.

### DIFF
--- a/ckeditor/fields.py
+++ b/ckeditor/fields.py
@@ -7,20 +7,24 @@ from ckeditor.widgets import CKEditorWidget
 class RichTextField(models.TextField):
     def __init__(self, *args, **kwargs):
         self.config_name = kwargs.pop("config_name", "default")
+        self.extra_plugins = kwargs.pop("extra_plugins", [])
+        self.external_plugin_resources = kwargs.pop("external_plugin_resources", [])
         super(RichTextField, self).__init__(*args, **kwargs)
 
     def formfield(self, **kwargs):
         defaults = {
             'form_class': RichTextFormField,
             'config_name': self.config_name,
+            'extra_plugins' : self.extra_plugins,
+            'external_plugin_resources': self.external_plugin_resources
         }
         defaults.update(kwargs)
         return super(RichTextField, self).formfield(**defaults)
 
 
 class RichTextFormField(forms.fields.Field):
-    def __init__(self, config_name='default', *args, **kwargs):
-        kwargs.update({'widget': CKEditorWidget(config_name=config_name)})
+    def __init__(self, config_name='default', extra_plugins=None, external_plugin_resources=None, *args, **kwargs):
+        kwargs.update({'widget': CKEditorWidget(config_name=config_name, extra_plugins=extra_plugins, external_plugin_resources=external_plugin_resources)})
         super(RichTextFormField, self).__init__(*args, **kwargs)
 
 try:

--- a/ckeditor/templates/ckeditor/widget.html
+++ b/ckeditor/templates/ckeditor/widget.html
@@ -1,4 +1,7 @@
 <p><textarea{{ final_attrs|safe }}>{{ value }}</textarea></p>
 <script type="text/javascript">
+{% for plugin_name, base_path, resource_name in external_plugin_resources %}
+    CKEDITOR.plugins.addExternal("{{ plugin_name|escapejs }}", "{{ base_path|escapejs }}", "{{ resource_name|escapejs }}");
+{% endfor %}
     CKEDITOR.replace("{{ id }}", {{ config|safe }});
 </script>

--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -49,7 +49,7 @@ class CKEditorWidget(forms.Textarea):
                     uploaded media). Make sure to use a trailing slash: \
                     CKEDITOR_MEDIA_PREFIX = '/media/ckeditor/'")
 
-    def __init__(self, config_name='default', *args, **kwargs):
+    def __init__(self, config_name='default', extra_plugins=None, external_plugin_resources=None, *args, **kwargs):
         super(CKEditorWidget, self).__init__(*args, **kwargs)
         # Setup config from defaults.
         self.config = DEFAULT_CONFIG.copy()
@@ -75,6 +75,13 @@ class CKEditorWidget(forms.Textarea):
             else:
                 raise ImproperlyConfigured('CKEDITOR_CONFIGS setting must be a\
                         dictionary type.')
+        
+        extra_plugins = extra_plugins or []
+        
+        if extra_plugins:
+            self.config['extraPlugins'] = ','.join(extra_plugins)
+
+        self.external_plugin_resources = external_plugin_resources or []
 
     def render(self, name, value, attrs={}):
         if value is None:
@@ -89,5 +96,6 @@ class CKEditorWidget(forms.Textarea):
             'final_attrs': flatatt(final_attrs),
             'value': conditional_escape(force_text(value)),
             'id': final_attrs['id'],
-            'config': json_encode(self.config)
+            'config': json_encode(self.config),
+            'external_plugin_resources' : self.external_plugin_resources
         }))


### PR DESCRIPTION
This commit adds keyword arguments to fields.RichTextField that allow the
overriding of extraPlugins on a per-field basis, and that allow the declaration
of external plugin resources (using CKEDITOR.plugins.addExternal()).

This improves the implementation of CKEditor plugins in django apps,
because they can be hosted and deployed separately from the CKEditor sources.

As an example, here's how to define a custom RichTextField by just currying
the existing one's constructor with the new arguments:

``` python
from django.utils.functional import curry

extra_plugins = ['custom_plugin']
external_plugin_resources=[('custom_plugin', '/custom_plugin_base/', 'plugin.js')]
CustomRichTextField = curry(RichTextField, extra_plugins=extra_plugins, external_plugin_resources=external_plugin_resources)
```

The external_plugin_resources kwarg is a list of tuples that contain the same
information as the parameters to CKEDITOR.plugins.addExternal().
You may want to write "reverse('some_view')" for the second parameter.
If that fails due to circular imports, wrap the reverse() call in a
SimpleLazyObject, like this:

``` python
from django.utils.functional import SimpleLazyObject
external_plugin_resources=[('custom_plugin', SimpleLazyObject(lambda: reverse('custom_plugin_view', kwargs=...) + 'some_relative_path/'), 'plugin.js')]
```
