### PR TITLE
CKEditor in admin inline bug fix

### DIFF
--- a/ckeditor/static/ckeditor/ckeditor-init.js
+++ b/ckeditor/static/ckeditor/ckeditor-init.js
@@ -1,0 +1,19 @@
+jQuery(function(){
+
+    function initCKEditor(){
+        $('textarea[data-type=ckeditortype]').each(function(){
+            if($(this).data('processed') == "0" && $(this).attr('id').indexOf('__prefix__') == -1){
+                $(this).data('processed',"1");
+                CKEDITOR.replace($(this).attr('id'), $(this).data('config'));
+            }
+        });
+    }
+
+    initCKEditor();
+
+    $(".add-row a").click(function(){
+        initCKEditor();
+        return true;
+    });
+
+});

--- a/ckeditor/templates/ckeditor/widget.html
+++ b/ckeditor/templates/ckeditor/widget.html
@@ -1,10 +1,3 @@
-<p><textarea{{ final_attrs|safe }}>{{ value }}</textarea></p>
-<script type="text/javascript">
-    if (typeof CKEDITOR == "undefined") {
-        $( document ).ready(function() {
-            CKEDITOR.replace("{{ id }}", {{ config|safe }});
-        });
-    } else {
-        CKEDITOR.replace("{{ id }}", {{ config|safe }});
-    }
-</script>
+<div style="margin-left: 106px">
+    <textarea{{ final_attrs|safe }} data-processed="0" data-config='{{config|safe}}' data-id="{{id}}" data-type="ckeditortype">{{ value }}</textarea>
+</div>

--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -40,7 +40,9 @@ class CKEditorWidget(forms.Textarea):
     class Media:
         try:
             js = (
+                'http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js',
                 settings.STATIC_URL + 'ckeditor/ckeditor/ckeditor.js',
+                settings.STATIC_URL + 'ckeditor/ckeditor-init.js',
             )
         except AttributeError:
             raise ImproperlyConfigured("django-ckeditor requires \
@@ -75,9 +77,9 @@ class CKEditorWidget(forms.Textarea):
             else:
                 raise ImproperlyConfigured('CKEDITOR_CONFIGS setting must be a\
                         dictionary type.')
-        
+
         extra_plugins = extra_plugins or []
-        
+
         if extra_plugins:
             self.config['extraPlugins'] = ','.join(extra_plugins)
 


### PR DESCRIPTION
There is a bug which prevents editors in admin inlines from being properly initialized.

For example if you have some admin.StackedInline with extra = 0 and RichTextField inside it, the field appears to be unclickable after you hit "Add a row". So you need a lazy initialization for these.

So I cherry-picked a solution from another fork that was outdated.
